### PR TITLE
Return object array on post

### DIFF
--- a/Service/RequestService.php
+++ b/Service/RequestService.php
@@ -541,7 +541,7 @@ class RequestService
                     // Use validation to throw an error
                 }
 
-                $result = $this->cacheService->getObject($this->object->getId());
+                $result = $this->cacheService->getObject($this->object->toArray());
                 break;
             case 'PUT':
                 $eventType = 'commongateway.object.update';

--- a/Service/RequestService.php
+++ b/Service/RequestService.php
@@ -536,12 +536,16 @@ class RequestService
                         $this->entityManager->flush();
                         $this->session->set('object', $this->object->getId()->toString());
                         $this->cacheService->cacheObject($this->object); /* @todo this is hacky, the above schould alredy do this */
+                    } else {
+                        $this->entityManager->persist($this->object);
+                        $this->session->set('object', $this->object->getId()->toString());
+                        $this->cacheService->cacheObject($this->object); /* @todo this is hacky, the above schould alredy do this */
                     }
                 } else {
                     // Use validation to throw an error
                 }
 
-                $result = $this->cacheService->getObject($this->object->toArray());
+                $result = $this->cacheService->getObject($this->object->getId()->toString());
                 break;
             case 'PUT':
                 $eventType = 'commongateway.object.update';


### PR DESCRIPTION
As non persisted objects are not cached, nor do they get an ID, we cannot pull this from the cache.