### PR TITLE
Unset query parameters on 'all' keywords

### DIFF
--- a/Service/RequestService.php
+++ b/Service/RequestService.php
@@ -375,6 +375,12 @@ class RequestService
             //                $filters[$key] = $value;
             //            }
             $filters = $this->realRequestQueryAll($this->data['method']);
+
+            foreach($filters as $key=>$value) {
+                if($value === 'all' || $value === 'alles' || $value === '*') {
+                    unset($filters[$key]);
+                }
+            }
         }
 
         // Get the ID

--- a/Service/RequestService.php
+++ b/Service/RequestService.php
@@ -376,8 +376,8 @@ class RequestService
             //            }
             $filters = $this->realRequestQueryAll($this->data['method']);
 
-            foreach($filters as $key=>$value) {
-                if($value === 'all' || $value === 'alles' || $value === '*') {
+            foreach ($filters as $key=>$value) {
+                if ($value === 'all' || $value === 'alles' || $value === '*') {
                     unset($filters[$key]);
                 }
             }


### PR DESCRIPTION
This PR makes it so that if the value of a query parameter is in the following list, the filter is removed from the filter stack:
- 'all'
- 'alles' (dutch version of all)
- '*'