### PR TITLE
Properly handle prefixed endpoints containing /api/

### DIFF
--- a/src/Service/EndpointService.php
+++ b/src/Service/EndpointService.php
@@ -207,36 +207,36 @@ class EndpointService
         // Determine the accept type.
         $this->logger->debug('Determine accept type from accept header');
         switch ($acceptHeader) {
-            case 'application/pdf':
-                return 'pdf';
-            case 'application/json':
-                return 'json';
-            case 'application/json+hal':
-            case 'application/hal+json':
-                return 'jsonhal';
-            case 'application/json+ld':
-            case 'application/ld+json':
-                return 'jsonld';
-            case 'application/json+fromio':
-            case 'application/formio+json':
-                return 'formio';
-            case 'application/json+schema':
-            case 'application/schema+json':
-                return 'schema';
-            case 'application/json+graphql':
-            case 'application/graphql+json':
-                return 'graphql';
-            case 'text/xml':
-            case 'application/xml':
-                return 'xml';
-            case 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet':
-                return 'xlsx';
-            case 'text/csv':
-                return 'csv';
-            case 'text/html':
-                return 'html';
-            case 'application/vnd.openxmlformats-officedocument.wordprocessingml.document':
-                return 'docx';
+        case 'application/pdf':
+            return 'pdf';
+        case 'application/json':
+            return 'json';
+        case 'application/json+hal':
+        case 'application/hal+json':
+            return 'jsonhal';
+        case 'application/json+ld':
+        case 'application/ld+json':
+            return 'jsonld';
+        case 'application/json+fromio':
+        case 'application/formio+json':
+            return 'formio';
+        case 'application/json+schema':
+        case 'application/schema+json':
+            return 'schema';
+        case 'application/json+graphql':
+        case 'application/graphql+json':
+            return 'graphql';
+        case 'text/xml':
+        case 'application/xml':
+            return 'xml';
+        case 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet':
+            return 'xlsx';
+        case 'text/csv':
+            return 'csv';
+        case 'text/html':
+            return 'html';
+        case 'application/vnd.openxmlformats-officedocument.wordprocessingml.document':
+            return 'docx';
                 break;
         }//end switch
 
@@ -286,8 +286,8 @@ class EndpointService
         if (count($pathparts) >= 2) {
             $extension = end($pathparts);
             switch ($extension) {
-                case 'pdf':
-                    return 'pdf';
+            case 'pdf':
+                return 'pdf';
             }//end switch
         }
 
@@ -318,14 +318,14 @@ class EndpointService
 
         // Decode the body.
         switch ($contentType) {
-            case 'text/xml':
-            case 'application/xml':
-            case 'xml':
-                $xmlEncoder = new XmlEncoder();
+        case 'text/xml':
+        case 'application/xml':
+        case 'xml':
+            $xmlEncoder = new XmlEncoder();
 
-                return $xmlEncoder->decode($this->request->getContent(), 'xml');
-            default:
-                return json_decode($this->request->getContent(), true);
+            return $xmlEncoder->decode($this->request->getContent(), 'xml');
+        default:
+            return json_decode($this->request->getContent(), true);
         }//end switch
 
     }//end decodeBody()
@@ -338,7 +338,7 @@ class EndpointService
      */
     public function getEndpoint(): Endpoint
     {
-        $path     = $this->request->getPathInfo();
+        $path = $this->request->getPathInfo();
 
         // The third parameters ensures that /prefix/api/a/api/b will become ['/prefix', 'a/api/b'].
         // See https://www.php.net/manual/en/function.explode.php for more information.
@@ -410,10 +410,10 @@ class EndpointService
 
             $filename = null;
             if (preg_match(
-                    '/^(.+); *name="([^"]+)"(; *filename="([^"]+)")?/',
-                    $headers['content-disposition'],
-                    $matches
-                ) === false
+                '/^(.+); *name="([^"]+)"(; *filename="([^"]+)")?/',
+                $headers['content-disposition'],
+                $matches
+            ) === false
             ) {
                 preg_match(
                     '/^(.+); *name=([-+.\w]+)(; *filename=([-+.\w]+))?/',
@@ -428,14 +428,14 @@ class EndpointService
             // Handle your fields here.
             switch ($name) {
                 // This is a file upload.
-                case 'userfile':
-                    file_put_contents($filename, $body);
-                    break;
+            case 'userfile':
+                file_put_contents($filename, $body);
+                break;
 
                 // Default for all other files is to populate $data.
-                default:
-                    $data[$name] = substr($body, 0, (strlen($body) - 2));
-                    break;
+            default:
+                $data[$name] = substr($body, 0, (strlen($body) - 2));
+                break;
             }
         }//end foreach
 


### PR DESCRIPTION
The previous version would break if a path would contain /api/ twice, that is solved now.