### PR TITLE
Fix EndpointService event response

### DIFF
--- a/src/Service/EndpointService.php
+++ b/src/Service/EndpointService.php
@@ -162,12 +162,11 @@ class EndpointService
                 }
             }
 
-
             // If the response is set by any earlier event, we return it.
-            if (isset($response) ===  true) {
+            if (isset($response) === true) {
                 return $response;
             }
-        }
+        }//end if
 
         // If the response is set by any way else than an event, we return it.
         if (isset($parameters['response']) === true) {

--- a/src/Service/EndpointService.php
+++ b/src/Service/EndpointService.php
@@ -174,9 +174,10 @@ class EndpointService
             return$parameters['response'];
         }
 
-        $this->logger->error('No proxy, schema or events could be established for this endpoint. Actions might have been triggered but no response could be generated.');
+        $errorMessage = 'No proxy, schema or events could be established for this endpoint. Actions might have been triggered but if so, no response could be generated.';
 
-        throw new Exception('No proxy, schema or events could be established for this endpoint. Actions might have been triggered but no response could be generated.');
+        $this->logger->error($errorMessage);
+        throw new Exception($errorMessage);
 
     }//end handleRequest()
 

--- a/src/Service/EndpointService.php
+++ b/src/Service/EndpointService.php
@@ -155,19 +155,28 @@ class EndpointService
             foreach ($endpoint->getThrows() as $throw) {
                 $event = new ActionEvent('commongateway.action.event', $parameters, $throw);
                 $this->eventDispatcher->dispatch($event, 'commongateway.action.event');
-                $parameters['response'] = $event->getData()['response'];
+
+                // If the response is set by the event, we assign it.
+                if (isset($event->getData()['response']) === true) {
+                    $response = $event->getData()['response'];
+                }
             }
 
-            $parameters['response'] = $event->getData()['response'];
+
+            // If the response is set by any earlier event, we return it.
+            if (isset($response) ===  true) {
+                return $response;
+            }
         }
 
+        // If the response is set by any way else than an event, we return it.
         if (isset($parameters['response']) === true) {
-            return $parameters['response'];
+            return$parameters['response'];
         }
 
-        $this->logger->error('No proxy, schema or events could be established for this endpoint');
+        $this->logger->error('No proxy, schema or events could be established for this endpoint. Actions might have been triggered but no response could be generated.');
 
-        throw new Exception('No proxy, schema or events could be established for this endpoint');
+        throw new Exception('No proxy, schema or events could be established for this endpoint. Actions might have been triggered but no response could be generated.');
 
     }//end handleRequest()
 

--- a/src/Service/EndpointService.php
+++ b/src/Service/EndpointService.php
@@ -173,7 +173,7 @@ class EndpointService
             return$parameters['response'];
         }
 
-        $errorMessage = 'No proxy, schema or events could be established for this endpoint. Actions might have been triggered but if so, no response could be generated.';
+        $errorMessage = 'No proxy or schema could be established for this endpoint. Events might have been triggered but if so, no response has been returned.';
 
         $this->logger->error($errorMessage);
         throw new Exception($errorMessage);


### PR DESCRIPTION
If there isn't a response on the latest event the service crashes, now fixed by adding more checks
